### PR TITLE
Log to syslog when run from cron/launchd

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -5,6 +5,7 @@ class AwsRotateIamKeys < Formula
   sha256 "bff7a999f402db12114fae91d46455e5f36b9559fd4a07caad09c5f42a99b8d6"
   depends_on "awscli"
   depends_on "jq"
+  depends_on "gnu-getopt"
 
   def install
     bin.install "src/bin/aws-rotate-iam-keys"

--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -4,8 +4,8 @@ class AwsRotateIamKeys < Formula
   url "https://github.com/rhyeal/aws-rotate-iam-keys/archive/v0.8.1.tar.gz"
   sha256 "bff7a999f402db12114fae91d46455e5f36b9559fd4a07caad09c5f42a99b8d6"
   depends_on "awscli"
-  depends_on "jq"
   depends_on "gnu-getopt"
+  depends_on "jq"
 
   def install
     bin.install "src/bin/aws-rotate-iam-keys"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ EDITOR=nano crontab -e
 Copy and paste the following line into the end of the crontab file:
 
 ```
-33 4 * * * /usr/local/bin/aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
+33 4 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
 ```
 
 Save your crontab with `Ctrl` + `O` and then press `[Enter]`. Exit and apply changes with `Ctrl` + `X`. That's it!

--- a/README.template.md
+++ b/README.template.md
@@ -102,7 +102,7 @@ EDITOR=nano crontab -e
 Copy and paste the following line into the end of the crontab file:
 
 ```
-33 4 * * * /usr/local/bin/aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
+33 4 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
 ```
 
 Save your crontab with `Ctrl` + `O` and then press `[Enter]`. Exit and apply changes with `Ctrl` + `X`. That's it!

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -7,8 +7,8 @@ IFS=$'\n\t'
 
 ! getopt --test > /dev/null
 if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
-    if which brew &> /dev/null && test -d /usr/local/opt/gnu-getopt/bin; then
-        PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+    if which brew &> /dev/null && test -d $(brew --prefix)/opt/gnu-getopt/bin; then
+        PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
     else
         echo "I’m sorry, 'getopt --test' failed in this environment."
         exit 1

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Log to syslog if output streams not attached to a terminal (cron, launchd)
+if ! test -t 1 && ! test -t 2; then
+  exec 1> >(tee >(logger -t $(basename $0))) 2>&1
+fi
+
 # Assign the arguments to variables
 # saner programming env: these switches turn some bugs into errors
 set -eu -o errexit -o pipefail -o noclobber -o nounset

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -7,8 +7,12 @@ IFS=$'\n\t'
 
 ! getopt --test > /dev/null
 if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
-    echo "I’m sorry, 'getopt --test' failed in this environment."
-    exit 1
+    if which brew &> /dev/null && test -d /usr/local/opt/gnu-getopt/bin; then
+        PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+    else
+        echo "I’m sorry, 'getopt --test' failed in this environment."
+        exit 1
+    fi
 fi
 
 # -use ! and PIPESTATUS to get exit code with errexit set

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -7,7 +7,7 @@ IFS=$'\n\t'
 
 ! getopt --test > /dev/null
 if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
-    echo "I’m sorry, `getopt --test` failed in this environment."
+    echo "I’m sorry, 'getopt --test' failed in this environment."
     exit 1
 fi
 


### PR DESCRIPTION
To aid debugging when things go wrong, especially during initial setup
of scheduled tasks, log output to syslog when output streams are not
attached to a terminal (e.g. when program is run from cron or launchd)