### PR TITLE
Improve launchd example, make it easier to rotate multiple keys

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -5,6 +5,7 @@ class AwsRotateIamKeys < Formula
   sha256 "bff7a999f402db12114fae91d46455e5f36b9559fd4a07caad09c5f42a99b8d6"
   depends_on "awscli"
   depends_on "jq"
+  depends_on "gnu-getopt"
 
   def install
     bin.install "src/bin/aws-rotate-iam-keys"

--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -4,8 +4,8 @@ class AwsRotateIamKeys < Formula
   url "https://github.com/rhyeal/aws-rotate-iam-keys/archive/v0.8.1.tar.gz"
   sha256 "bff7a999f402db12114fae91d46455e5f36b9559fd4a07caad09c5f42a99b8d6"
   depends_on "awscli"
-  depends_on "jq"
   depends_on "gnu-getopt"
+  depends_on "jq"
 
   def install
     bin.install "src/bin/aws-rotate-iam-keys"

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Open a Terminal and cd into the Launch Agents directory. Make the plist file and
 
 ```
 cd ~/Library/LaunchAgents
-touch com.aws.rotate.iam.keys.plist
-nano com.aws.rotate.iam.keys.plist
+touch aws-rotate-iam-keys.plist
+nano aws-rotate-iam-keys.plist
 ```
 
 Copy and paste the following into your text editor:
@@ -126,41 +126,55 @@ Copy and paste the following into your text editor:
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>EnvironmentVariables</key>
-	<dict>
-		<key>PATH</key>
-		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-	</dict>
-	<key>Label</key>
-	<string>com.aws.rotate.iam.keys</string>
-	<key>ProgramArguments</key>
-	<array>
-		<string>/usr/local/bin/aws-rotate-iam-keys</string>
-		<string>--profile</string>
-		<string>default</string>
-	</array>
-	<key>StartCalendarInterval</key>
-	<dict>
-		<key>Hour</key>
-		<integer>3</integer>
-		<key>Minute</key>
-		<integer>23</integer>
-	</dict>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>Label</key>
+  <string>aws-rotate-iam-keys</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>aws-rotate-iam-keys --profile default</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>3</integer>
+    <key>Minute</key>
+    <integer>23</integer>
+  </dict>
 </dict>
 </plist>
 
+```
+
+To rotate multiple profiles with their own keys, remember that you need to
+invoke `aws-rotate-iam-keys` multiple times. You can do this by simply sending
+multiple commands to bash, separating each invocation with semi-colons, e.g.
+
+```
+...
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>aws-rotate-iam-keys -p myProfile ; aws-rotate-iam-keys -p myOtherProfile</string>
+  </array>
+...
 ```
 
 Save the file with `Ctrl` + `O` and then press `[Enter]`. Exit with `Ctrl` + `X`.
 
 Load up the launchd job with
 ```
-launchctl load -F ~/Library/LaunchAgents/com.aws.rotate.iam.keys.plist
+launchctl load -F ~/Library/LaunchAgents/aws-rotate-iam-keys.plist
 ```
 
 You can check that everything worked by running:
 ```
-launchctl start com.aws.rotate.iam.keys
+launchctl start aws-rotate-iam-keys
 ```
 
 That's it. Now your keys will be rotated every day for you.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Copy and paste the following into your text editor:
     <string>-c</string>
     <string>aws-rotate-iam-keys --profile default</string>
   </array>
+  <key>RunAtLoad</key>
+  <true/>
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key>
@@ -172,12 +174,10 @@ Load up the launchd job with
 launchctl load -F ~/Library/LaunchAgents/aws-rotate-iam-keys.plist
 ```
 
-You can check that everything worked by running:
-```
-launchctl start aws-rotate-iam-keys
-```
-
-That's it. Now your keys will be rotated every day for you.
+That's it. Your keys should have been rotated, and will now be rotated every
+day for you. You can confirm everything has worked by checking your IAM
+credentials to confirm the access keys have been rotated. If it hasn't worked,
+check the MacOS system log for error entries matching `aws-rotate-iam-keys`.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ EDITOR=nano crontab -e
 Copy and paste the following line into the end of the crontab file:
 
 ```
-33 4 * * * /usr/local/bin/aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
+33 4 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
 ```
 
 Save your crontab with `Ctrl` + `O` and then press `[Enter]`. Exit and apply changes with `Ctrl` + `X`. That's it!

--- a/README.md
+++ b/README.md
@@ -102,14 +102,16 @@ EDITOR=nano crontab -e
 Copy and paste the following line into the end of the crontab file:
 
 ```
-33 4 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
+45 9 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
 ```
+
+Note: MacOS cron skips job invocations when the computer is asleep, so you should schedule the job to run at a time when your computer is likely to be awake.
 
 Save your crontab with `Ctrl` + `O` and then press `[Enter]`. Exit and apply changes with `Ctrl` + `X`. That's it!
 
-#### Using launchd (MacOS recommended)
+#### Using launchd (recommended)
 
-[Launchd](http://www.launchd.info/) is the MacOS replacement for cron.
+[Launchd](http://www.launchd.info/) is the MacOS replacement for cron. Unlike cron, which skips job invocations when the computer is asleep, launchd will start the job the next time the computer wakes up.
 
 Open a Terminal and cd into the Launch Agents directory. Make the plist file and open your text editor.
 

--- a/README.template.md
+++ b/README.template.md
@@ -115,8 +115,8 @@ Open a Terminal and cd into the Launch Agents directory. Make the plist file and
 
 ```
 cd ~/Library/LaunchAgents
-touch com.aws.rotate.iam.keys.plist
-nano com.aws.rotate.iam.keys.plist
+touch aws-rotate-iam-keys.plist
+nano aws-rotate-iam-keys.plist
 ```
 
 Copy and paste the following into your text editor:
@@ -126,41 +126,55 @@ Copy and paste the following into your text editor:
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>EnvironmentVariables</key>
-	<dict>
-		<key>PATH</key>
-		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-	</dict>
-	<key>Label</key>
-	<string>com.aws.rotate.iam.keys</string>
-	<key>ProgramArguments</key>
-	<array>
-		<string>/usr/local/bin/aws-rotate-iam-keys</string>
-		<string>--profile</string>
-		<string>default</string>
-	</array>
-	<key>StartCalendarInterval</key>
-	<dict>
-		<key>Hour</key>
-		<integer>3</integer>
-		<key>Minute</key>
-		<integer>23</integer>
-	</dict>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>Label</key>
+  <string>aws-rotate-iam-keys</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>aws-rotate-iam-keys --profile default</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>3</integer>
+    <key>Minute</key>
+    <integer>23</integer>
+  </dict>
 </dict>
 </plist>
 
+```
+
+To rotate multiple profiles with their own keys, remember that you need to
+invoke `aws-rotate-iam-keys` multiple times. You can do this by simply sending
+multiple commands to bash, separating each invocation with semi-colons, e.g.
+
+```
+...
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>aws-rotate-iam-keys -p myProfile ; aws-rotate-iam-keys -p myOtherProfile</string>
+  </array>
+...
 ```
 
 Save the file with `Ctrl` + `O` and then press `[Enter]`. Exit with `Ctrl` + `X`.
 
 Load up the launchd job with
 ```
-launchctl load -F ~/Library/LaunchAgents/com.aws.rotate.iam.keys.plist
+launchctl load -F ~/Library/LaunchAgents/aws-rotate-iam-keys.plist
 ```
 
 You can check that everything worked by running:
 ```
-launchctl start com.aws.rotate.iam.keys
+launchctl start aws-rotate-iam-keys
 ```
 
 That's it. Now your keys will be rotated every day for you.

--- a/README.template.md
+++ b/README.template.md
@@ -139,6 +139,8 @@ Copy and paste the following into your text editor:
     <string>-c</string>
     <string>aws-rotate-iam-keys --profile default</string>
   </array>
+  <key>RunAtLoad</key>
+  <true/>
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key>
@@ -172,12 +174,10 @@ Load up the launchd job with
 launchctl load -F ~/Library/LaunchAgents/aws-rotate-iam-keys.plist
 ```
 
-You can check that everything worked by running:
-```
-launchctl start aws-rotate-iam-keys
-```
-
-That's it. Now your keys will be rotated every day for you.
+That's it. Your keys should have been rotated, and will now be rotated every
+day for you. You can confirm everything has worked by checking your IAM
+credentials to confirm the access keys have been rotated. If it hasn't worked,
+check the MacOS system log for error entries matching `aws-rotate-iam-keys`.
 
 ### Windows
 

--- a/README.template.md
+++ b/README.template.md
@@ -102,7 +102,7 @@ EDITOR=nano crontab -e
 Copy and paste the following line into the end of the crontab file:
 
 ```
-33 4 * * * /usr/local/bin/aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
+33 4 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
 ```
 
 Save your crontab with `Ctrl` + `O` and then press `[Enter]`. Exit and apply changes with `Ctrl` + `X`. That's it!

--- a/README.template.md
+++ b/README.template.md
@@ -102,14 +102,16 @@ EDITOR=nano crontab -e
 Copy and paste the following line into the end of the crontab file:
 
 ```
-33 4 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
+45 9 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
 ```
+
+Note: MacOS cron skips job invocations when the computer is asleep, so you should schedule the job to run at a time when your computer is likely to be awake.
 
 Save your crontab with `Ctrl` + `O` and then press `[Enter]`. Exit and apply changes with `Ctrl` + `X`. That's it!
 
-#### Using launchd (MacOS recommended)
+#### Using launchd (recommended)
 
-[Launchd](http://www.launchd.info/) is the MacOS replacement for cron.
+[Launchd](http://www.launchd.info/) is the MacOS replacement for cron. Unlike cron, which skips job invocations when the computer is asleep, launchd will start the job the next time the computer wakes up.
 
 Open a Terminal and cd into the Launch Agents directory. Make the plist file and open your text editor.
 

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -7,8 +7,8 @@ IFS=$'\n\t'
 
 ! getopt --test > /dev/null
 if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
-    if which brew &> /dev/null && test -d /usr/local/opt/gnu-getopt/bin; then
-        PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+    if which brew &> /dev/null && test -d $(brew --prefix)/opt/gnu-getopt/bin; then
+        PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
     else
         echo "I’m sorry, 'getopt --test' failed in this environment."
         exit 1

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Log to syslog if output streams not attached to a terminal (cron, launchd)
+if ! test -t 1 && ! test -t 2; then
+  exec 1> >(tee >(logger -t $(basename $0))) 2>&1
+fi
+
 # Assign the arguments to variables
 # saner programming env: these switches turn some bugs into errors
 set -eu -o errexit -o pipefail -o noclobber -o nounset

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -7,8 +7,12 @@ IFS=$'\n\t'
 
 ! getopt --test > /dev/null
 if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
-    echo "I’m sorry, 'getopt --test' failed in this environment."
-    exit 1
+    if which brew &> /dev/null && test -d /usr/local/opt/gnu-getopt/bin; then
+        PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+    else
+        echo "I’m sorry, 'getopt --test' failed in this environment."
+        exit 1
+    fi
 fi
 
 # -use ! and PIPESTATUS to get exit code with errexit set

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -7,7 +7,7 @@ IFS=$'\n\t'
 
 ! getopt --test > /dev/null
 if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
-    echo "I’m sorry, `getopt --test` failed in this environment."
+    echo "I’m sorry, 'getopt --test' failed in this environment."
     exit 1
 fi
 


### PR DESCRIPTION
Update example plist file in the readme to invoke command via `bash -c`, which makes it possible to rotate multiple keys using a single plist file, by simply passing multiple commands to bash. 

Also update the job to run at load so it works for users who power off overnight, and update readme to explain why launchd is recommended over cron (unlike cron, launchd will catch up on jobs that were scheduled to run while the computer was asleep).

Finally, simplify the name of the plist file to just use the script name, which is enough to uniquely identify the job.