### PR TITLE
Use homebrew services to schedule rotation on Mac

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -5,6 +5,7 @@ class AwsRotateIamKeys < Formula
   sha256 "bff7a999f402db12114fae91d46455e5f36b9559fd4a07caad09c5f42a99b8d6"
   depends_on "awscli"
   depends_on "jq"
+  depends_on "gnu-getopt"
 
   def install
     bin.install "src/bin/aws-rotate-iam-keys"

--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -4,8 +4,8 @@ class AwsRotateIamKeys < Formula
   url "https://github.com/rhyeal/aws-rotate-iam-keys/archive/v0.8.1.tar.gz"
   sha256 "bff7a999f402db12114fae91d46455e5f36b9559fd4a07caad09c5f42a99b8d6"
   depends_on "awscli"
-  depends_on "jq"
   depends_on "gnu-getopt"
+  depends_on "jq"
 
   def install
     bin.install "src/bin/aws-rotate-iam-keys"

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Open a Terminal and cd into the Launch Agents directory. Make the plist file and
 
 ```
 cd ~/Library/LaunchAgents
-touch com.aws.rotate.iam.keys.plist
-nano com.aws.rotate.iam.keys.plist
+touch aws-rotate-iam-keys.plist
+nano aws-rotate-iam-keys.plist
 ```
 
 Copy and paste the following into your text editor:
@@ -126,41 +126,55 @@ Copy and paste the following into your text editor:
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>EnvironmentVariables</key>
-	<dict>
-		<key>PATH</key>
-		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-	</dict>
-	<key>Label</key>
-	<string>com.aws.rotate.iam.keys</string>
-	<key>ProgramArguments</key>
-	<array>
-		<string>/usr/local/bin/aws-rotate-iam-keys</string>
-		<string>--profile</string>
-		<string>default</string>
-	</array>
-	<key>StartCalendarInterval</key>
-	<dict>
-		<key>Hour</key>
-		<integer>3</integer>
-		<key>Minute</key>
-		<integer>23</integer>
-	</dict>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>Label</key>
+  <string>aws-rotate-iam-keys</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>aws-rotate-iam-keys --profile default</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>3</integer>
+    <key>Minute</key>
+    <integer>23</integer>
+  </dict>
 </dict>
 </plist>
 
+```
+
+To rotate multiple profiles with their own keys, remember that you need to
+invoke `aws-rotate-iam-keys` multiple times. You can do this by simply sending
+multiple commands to bash, separating each invocation with semi-colons, e.g.
+
+```
+...
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>aws-rotate-iam-keys -p myProfile ; aws-rotate-iam-keys -p myOtherProfile</string>
+  </array>
+...
 ```
 
 Save the file with `Ctrl` + `O` and then press `[Enter]`. Exit with `Ctrl` + `X`.
 
 Load up the launchd job with
 ```
-launchctl load -F ~/Library/LaunchAgents/com.aws.rotate.iam.keys.plist
+launchctl load -F ~/Library/LaunchAgents/aws-rotate-iam-keys.plist
 ```
 
 You can check that everything worked by running:
 ```
-launchctl start com.aws.rotate.iam.keys
+launchctl start aws-rotate-iam-keys
 ```
 
 That's it. Now your keys will be rotated every day for you.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Copy and paste the following into your text editor:
     <string>-c</string>
     <string>aws-rotate-iam-keys --profile default</string>
   </array>
+  <key>RunAtLoad</key>
+  <true/>
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key>
@@ -172,12 +174,10 @@ Load up the launchd job with
 launchctl load -F ~/Library/LaunchAgents/aws-rotate-iam-keys.plist
 ```
 
-You can check that everything worked by running:
-```
-launchctl start aws-rotate-iam-keys
-```
-
-That's it. Now your keys will be rotated every day for you.
+That's it. Your keys should have been rotated, and will now be rotated every
+day for you. You can confirm everything has worked by checking your IAM
+credentials to confirm the access keys have been rotated. If it hasn't worked,
+check the MacOS system log for error entries matching `aws-rotate-iam-keys`.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ EDITOR=nano crontab -e
 Copy and paste the following line into the end of the crontab file:
 
 ```
-33 4 * * * /usr/local/bin/aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
+33 4 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
 ```
 
 Save your crontab with `Ctrl` + `O` and then press `[Enter]`. Exit and apply changes with `Ctrl` + `X`. That's it!

--- a/README.md
+++ b/README.md
@@ -102,14 +102,16 @@ EDITOR=nano crontab -e
 Copy and paste the following line into the end of the crontab file:
 
 ```
-33 4 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
+45 9 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
 ```
+
+Note: MacOS cron skips job invocations when the computer is asleep, so you should schedule the job to run at a time when your computer is likely to be awake.
 
 Save your crontab with `Ctrl` + `O` and then press `[Enter]`. Exit and apply changes with `Ctrl` + `X`. That's it!
 
-#### Using launchd (MacOS recommended)
+#### Using launchd (recommended)
 
-[Launchd](http://www.launchd.info/) is the MacOS replacement for cron.
+[Launchd](http://www.launchd.info/) is the MacOS replacement for cron. Unlike cron, which skips job invocations when the computer is asleep, launchd will start the job the next time the computer wakes up.
 
 Open a Terminal and cd into the Launch Agents directory. Make the plist file and open your text editor.
 

--- a/README.template.md
+++ b/README.template.md
@@ -115,8 +115,8 @@ Open a Terminal and cd into the Launch Agents directory. Make the plist file and
 
 ```
 cd ~/Library/LaunchAgents
-touch com.aws.rotate.iam.keys.plist
-nano com.aws.rotate.iam.keys.plist
+touch aws-rotate-iam-keys.plist
+nano aws-rotate-iam-keys.plist
 ```
 
 Copy and paste the following into your text editor:
@@ -126,41 +126,55 @@ Copy and paste the following into your text editor:
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>EnvironmentVariables</key>
-	<dict>
-		<key>PATH</key>
-		<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-	</dict>
-	<key>Label</key>
-	<string>com.aws.rotate.iam.keys</string>
-	<key>ProgramArguments</key>
-	<array>
-		<string>/usr/local/bin/aws-rotate-iam-keys</string>
-		<string>--profile</string>
-		<string>default</string>
-	</array>
-	<key>StartCalendarInterval</key>
-	<dict>
-		<key>Hour</key>
-		<integer>3</integer>
-		<key>Minute</key>
-		<integer>23</integer>
-	</dict>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>Label</key>
+  <string>aws-rotate-iam-keys</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>aws-rotate-iam-keys --profile default</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>3</integer>
+    <key>Minute</key>
+    <integer>23</integer>
+  </dict>
 </dict>
 </plist>
 
+```
+
+To rotate multiple profiles with their own keys, remember that you need to
+invoke `aws-rotate-iam-keys` multiple times. You can do this by simply sending
+multiple commands to bash, separating each invocation with semi-colons, e.g.
+
+```
+...
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>aws-rotate-iam-keys -p myProfile ; aws-rotate-iam-keys -p myOtherProfile</string>
+  </array>
+...
 ```
 
 Save the file with `Ctrl` + `O` and then press `[Enter]`. Exit with `Ctrl` + `X`.
 
 Load up the launchd job with
 ```
-launchctl load -F ~/Library/LaunchAgents/com.aws.rotate.iam.keys.plist
+launchctl load -F ~/Library/LaunchAgents/aws-rotate-iam-keys.plist
 ```
 
 You can check that everything worked by running:
 ```
-launchctl start com.aws.rotate.iam.keys
+launchctl start aws-rotate-iam-keys
 ```
 
 That's it. Now your keys will be rotated every day for you.

--- a/README.template.md
+++ b/README.template.md
@@ -139,6 +139,8 @@ Copy and paste the following into your text editor:
     <string>-c</string>
     <string>aws-rotate-iam-keys --profile default</string>
   </array>
+  <key>RunAtLoad</key>
+  <true/>
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key>
@@ -172,12 +174,10 @@ Load up the launchd job with
 launchctl load -F ~/Library/LaunchAgents/aws-rotate-iam-keys.plist
 ```
 
-You can check that everything worked by running:
-```
-launchctl start aws-rotate-iam-keys
-```
-
-That's it. Now your keys will be rotated every day for you.
+That's it. Your keys should have been rotated, and will now be rotated every
+day for you. You can confirm everything has worked by checking your IAM
+credentials to confirm the access keys have been rotated. If it hasn't worked,
+check the MacOS system log for error entries matching `aws-rotate-iam-keys`.
 
 ### Windows
 

--- a/README.template.md
+++ b/README.template.md
@@ -102,7 +102,7 @@ EDITOR=nano crontab -e
 Copy and paste the following line into the end of the crontab file:
 
 ```
-33 4 * * * /usr/local/bin/aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
+33 4 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
 ```
 
 Save your crontab with `Ctrl` + `O` and then press `[Enter]`. Exit and apply changes with `Ctrl` + `X`. That's it!

--- a/README.template.md
+++ b/README.template.md
@@ -20,7 +20,7 @@ brew install aws-rotate-iam-keys
 ```
 Requires [Homebrew](https://brew.sh/) to install. I am hoping to be included in Homebrew Core soon!
 
-***IMPORTANT:*** You must install your own cron job for automated key rotation. [Instructions here](https://github.com/rhyeal/aws-rotate-iam-keys#macos-1) or scroll down to `Additional Cron Instructions` below.
+***IMPORTANT:*** You must install your own cron job for automated key rotation. [Instructions here](#macos-1) or scroll down to `Additional Cron Instructions` below.
 
 ### Other Linux
 
@@ -89,9 +89,60 @@ via the package managers selected to create their own cron schedules.
 
 ### MacOS
 
-MacOS does not allow programs to modify the crontab when installing via Homebrew. Unfortunately, this means that MacOS users will need to manually finish installation to automate AWS Rotate IAM Keys. Here's how to do that:
+#### Using launchd via Homebrew services (recommended)
 
-#### Using a cron job (easiest)
+[Launchd](http://www.launchd.info/) is the MacOS replacement for cron. Unlike
+cron, which on MacOS skips job invocations when the computer is asleep, launchd
+will start the job the next time the computer wakes up.
+
+The Homebrew package installs a launchd job which can be used to automatically
+rotate your IAM keys daily. Unfortunately, Homebrew packages cannot
+automatically start launchd jobs, so you must manually enable it:
+
+```
+brew services start aws-rotate-iam-keys
+```
+
+A default/global configuration file for the launchd job is installed to:
+
+```
+/usr/local/etc/aws-rotate-iam-keys
+```
+
+This default configuration rotates keys for your default AWS profile only.
+To customise the configuration, for example to rotate multiple keys, create a
+copy of this file named `.aws-rotate-iam-keys` in your home directory and edit
+it, e.g.
+
+```
+cp /usr/local/etc/aws-rotate-iam-keys ~/.aws-rotate-iam-keys
+nano ~/.aws-rotate-iam-keys
+```
+
+The `aws-rotate-iam-keys` command is invoked once daily for each line in the
+configuration. Each line contains a single set of command line options. If you
+need to invoke the command multiple times to rotate your keys, you must add
+multiple lines to the configuration, e.g.
+
+```
+--profiles default,myProfile
+--profile myOtherProfile
+```
+
+If you do customise the configuration, you can test that it works by restarting
+the service:
+
+```
+brew services restart aws-rotate-iam-keys
+```
+
+That's it. Your keys should have been rotated, and will now be rotated every
+day for you. You can confirm everything has worked by checking your IAM
+credentials to see if the access keys have been rotated as expected. If it
+hasn't worked, check the MacOS system log for error entries matching
+`aws-rotate-iam-keys`.
+
+#### Using a cron job (easier, but less reliable)
 
 Open your crontab by typing:
 
@@ -108,78 +159,6 @@ Copy and paste the following line into the end of the crontab file:
 Note: MacOS cron skips job invocations when the computer is asleep, so you should schedule the job to run at a time when your computer is likely to be awake.
 
 Save your crontab with `Ctrl` + `O` and then press `[Enter]`. Exit and apply changes with `Ctrl` + `X`. That's it!
-
-#### Using launchd (recommended)
-
-[Launchd](http://www.launchd.info/) is the MacOS replacement for cron. Unlike cron, which skips job invocations when the computer is asleep, launchd will start the job the next time the computer wakes up.
-
-Open a Terminal and cd into the Launch Agents directory. Make the plist file and open your text editor.
-
-```
-cd ~/Library/LaunchAgents
-touch aws-rotate-iam-keys.plist
-nano aws-rotate-iam-keys.plist
-```
-
-Copy and paste the following into your text editor:
-
-```
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>PATH</key>
-    <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-  </dict>
-  <key>Label</key>
-  <string>aws-rotate-iam-keys</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/bin/bash</string>
-    <string>-c</string>
-    <string>aws-rotate-iam-keys --profile default</string>
-  </array>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>StartCalendarInterval</key>
-  <dict>
-    <key>Hour</key>
-    <integer>3</integer>
-    <key>Minute</key>
-    <integer>23</integer>
-  </dict>
-</dict>
-</plist>
-
-```
-
-To rotate multiple profiles with their own keys, remember that you need to
-invoke `aws-rotate-iam-keys` multiple times. You can do this by simply sending
-multiple commands to bash, separating each invocation with semi-colons, e.g.
-
-```
-...
-  <array>
-    <string>/bin/bash</string>
-    <string>-c</string>
-    <string>aws-rotate-iam-keys -p myProfile ; aws-rotate-iam-keys -p myOtherProfile</string>
-  </array>
-...
-```
-
-Save the file with `Ctrl` + `O` and then press `[Enter]`. Exit with `Ctrl` + `X`.
-
-Load up the launchd job with
-```
-launchctl load -F ~/Library/LaunchAgents/aws-rotate-iam-keys.plist
-```
-
-That's it. Your keys should have been rotated, and will now be rotated every
-day for you. You can confirm everything has worked by checking your IAM
-credentials to confirm the access keys have been rotated. If it hasn't worked,
-check the MacOS system log for error entries matching `aws-rotate-iam-keys`.
 
 ### Windows
 
@@ -198,7 +177,6 @@ in a snazzy single-page UI. It's basically this README with some colors.
 echo ${LINUX_MD5} aws-rotate-iam-keys.${VERSION}.deb | md5sum --check -
 ```
 ### MacOS
-
 Homebrew gets the release zip of the entire repo: `SHA256 2bbc39e9783907451d8ce1eaba93dc6775ad6797221122ec96ec671f23f6344f`
 
 ### Windows

--- a/README.template.md
+++ b/README.template.md
@@ -102,14 +102,16 @@ EDITOR=nano crontab -e
 Copy and paste the following line into the end of the crontab file:
 
 ```
-33 4 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
+45 9 * * * PATH=/usr/local/bin:$PATH aws-rotate-iam-keys --profile default >/dev/null 2>&1 #rotate AWS keys daily
 ```
+
+Note: MacOS cron skips job invocations when the computer is asleep, so you should schedule the job to run at a time when your computer is likely to be awake.
 
 Save your crontab with `Ctrl` + `O` and then press `[Enter]`. Exit and apply changes with `Ctrl` + `X`. That's it!
 
-#### Using launchd (MacOS recommended)
+#### Using launchd (recommended)
 
-[Launchd](http://www.launchd.info/) is the MacOS replacement for cron.
+[Launchd](http://www.launchd.info/) is the MacOS replacement for cron. Unlike cron, which skips job invocations when the computer is asleep, launchd will start the job the next time the computer wakes up.
 
 Open a Terminal and cd into the Launch Agents directory. Make the plist file and open your text editor.
 

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -7,8 +7,8 @@ IFS=$'\n\t'
 
 ! getopt --test > /dev/null
 if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
-    if which brew &> /dev/null && test -d /usr/local/opt/gnu-getopt/bin; then
-        PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+    if which brew &> /dev/null && test -d $(brew --prefix)/opt/gnu-getopt/bin; then
+        PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
     else
         echo "I’m sorry, 'getopt --test' failed in this environment."
         exit 1

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Log to syslog if output streams not attached to a terminal (cron, launchd)
+if ! test -t 1 && ! test -t 2; then
+  exec 1> >(tee >(logger -t $(basename $0))) 2>&1
+fi
+
 # Assign the arguments to variables
 # saner programming env: these switches turn some bugs into errors
 set -eu -o errexit -o pipefail -o noclobber -o nounset

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -7,8 +7,12 @@ IFS=$'\n\t'
 
 ! getopt --test > /dev/null
 if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
-    echo "I’m sorry, 'getopt --test' failed in this environment."
-    exit 1
+    if which brew &> /dev/null && test -d /usr/local/opt/gnu-getopt/bin; then
+        PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+    else
+        echo "I’m sorry, 'getopt --test' failed in this environment."
+        exit 1
+    fi
 fi
 
 # -use ! and PIPESTATUS to get exit code with errexit set

--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -7,7 +7,7 @@ IFS=$'\n\t'
 
 ! getopt --test > /dev/null
 if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
-    echo "I’m sorry, `getopt --test` failed in this environment."
+    echo "I’m sorry, 'getopt --test' failed in this environment."
     exit 1
 fi
 


### PR DESCRIPTION
Automatically install the launchd configuration by adding plist to the
homebrew formula, and instruct users to enable it using brew services.

Also update the launchd job to read a configuration file and invoke the
command multiple times, once for each line in the configuration file.

This is required to avoid users editing the plist file, which may be
overwritten by homebrew on upgrade/reinstall. The job now reads lines
from a global/default config at /usr/local/etc/aws-rotate-iam-keys or
local/user config at ~/.aws-rotate-iam-keys, and invokes the command
once for each line in the configuration. The configuration file format
is simple, each line contains a single set of command line options.