### PR TITLE
More launchd improvements

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -57,8 +57,12 @@ class AwsRotateIamKeys < Formula
       <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <string>( cat ~/.aws-rotate-iam-keys 2>/dev/null || cat #{etc}/aws-rotate-iam-keys ) | while read line; do aws-rotate-iam-keys $line; done</string>
+        <string>cp /dev/null /tmp/#{plist_name}.log ; ( cat ~/.aws-rotate-iam-keys 2>/dev/null || cat #{etc}/aws-rotate-iam-keys ) | while read line; do aws-rotate-iam-keys $line; done</string>
       </array>
+      <key>StandardOutPath</key>
+      <string>/tmp/#{plist_name}.log</string>
+      <key>StandardErrorPath</key>
+      <string>/tmp/#{plist_name}.log</string>
       <key>RunAtLoad</key>
       <true/>
       <key>StartCalendarInterval</key>

--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -57,7 +57,7 @@ class AwsRotateIamKeys < Formula
       <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <string>cp /dev/null /tmp/#{plist_name}.log ; ( cat ~/.aws-rotate-iam-keys 2>/dev/null || cat #{etc}/aws-rotate-iam-keys ) | while read line; do aws-rotate-iam-keys $line; done</string>
+        <string>if ! curl -s www.google.com > /dev/null; then sleep 60; fi; cp /dev/null /tmp/#{plist_name}.log ; ( cat ~/.aws-rotate-iam-keys 2>/dev/null || cat #{etc}/aws-rotate-iam-keys ) | while read line; do aws-rotate-iam-keys $line; done</string>
       </array>
       <key>StandardOutPath</key>
       <string>/tmp/#{plist_name}.log</string>

--- a/README.md
+++ b/README.md
@@ -204,7 +204,12 @@ aws iam list-access-keys --profile default
 ```
 
 If it hasn't worked, check the MacOS system log for error entries matching
-`aws-rotate-iam-keys`.
+`aws-rotate-iam-keys`. If you can't find anything useful, the launchd job also
+writes output to a file in the `/tmp` directory matching the job name, e.g.
+
+```
+/tmp/homebrew.mxcl.aws-rotate-iam-keys.log
+```
 
 ### Other Linux
 

--- a/README.template.md
+++ b/README.template.md
@@ -204,7 +204,12 @@ aws iam list-access-keys --profile default
 ```
 
 If it hasn't worked, check the MacOS system log for error entries matching
-`aws-rotate-iam-keys`.
+`aws-rotate-iam-keys`. If you can't find anything useful, the launchd job also
+writes output to a file in the `/tmp` directory matching the job name, e.g.
+
+```
+/tmp/homebrew.mxcl.aws-rotate-iam-keys.log
+```
 
 ### Other Linux
 


### PR DESCRIPTION
Add a custom launchd log file because MacOS unified logging sucks, and update the launchd job to wait a while for an internet connection as a workaround for "Could not connect to EndPoint" errors.

