### PR TITLE
Fix JSON parse error for AWS CLI call

### DIFF
--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -82,7 +82,7 @@ CURRENT_KEY_ID=$(aws iam list-access-keys --output json --profile $FIRST_PROFILE
 if [[ "$CURRENT_KEY_ID" != "" ]]; then
   # Make a new key
   echo "Making new access key"
-  RESPONSE=$(aws iam create-access-key --profile $FIRST_PROFILE | jq .AccessKey)
+  RESPONSE=$(aws iam create-access-key --output json --profile $FIRST_PROFILE | jq .AccessKey)
   ACCESS_KEY=$(echo $RESPONSE | jq '.AccessKeyId' | tr -d '"')
   SECRET=$(echo $RESPONSE | jq '.SecretAccessKey' | tr -d '"')
   if [[ "$ACCESS_KEY" != "" && "$SECRET" != "" ]]; then


### PR DESCRIPTION
Fixes a JSON parse error that would prevent keys from being rotated successfully when a user's AWS config is not set to output JSON. The specific AWS CLI call expects JSON output but did not explicitly set the output format. 

Fixes #10 