### PR TITLE
Allow homebrew install to skip awscli, python etc.

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -1,5 +1,5 @@
 class AwsRotateIamKeys < Formula
-  desc "Automatically set up a cron job to rotate your IAM keys"
+  desc "Automatically rotate your IAM keys daily"
   homepage "https://aws-rotate-iam-keys.com"
   url "https://github.com/rhyeal/aws-rotate-iam-keys/archive/v0.9.2.tar.gz"
   sha256 "9101bff2a889e5c883fda99b12588dd50bee9d42faf77f6d6e5d94ab35abb9e1"

--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -3,7 +3,7 @@ class AwsRotateIamKeys < Formula
   homepage "https://aws-rotate-iam-keys.com"
   url "https://github.com/rhyeal/aws-rotate-iam-keys/archive/v0.9.2.tar.gz"
   sha256 "9101bff2a889e5c883fda99b12588dd50bee9d42faf77f6d6e5d94ab35abb9e1"
-  depends_on "awscli"
+  depends_on "awscli" => :recommended
   depends_on "gnu-getopt"
   depends_on "jq"
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,16 @@ sudo apt-get install aws-rotate-iam-keys
 
 ### MacOS
 
+Requires [Homebrew](https://brew.sh/) to install. I am hoping to be included in
+Homebrew Core soon!
+
 ```
 brew tap rhyeal/aws-rotate-iam-keys https://github.com/rhyeal/aws-rotate-iam-keys
 brew install aws-rotate-iam-keys
 ```
 
-Requires [Homebrew](https://brew.sh/) to install. I am hoping to be included in
-Homebrew Core soon!
+Note: this automatically installs/upgrades the `awscli` homebrew package and its
+dependent packages. You can skip this using `brew install aws-rotate-iam-keys --without-awscli`.
 
 ***IMPORTANT:*** You must install your own scheduled job for automated key
 rotation. See [Configuration](#configuration).

--- a/README.template.md
+++ b/README.template.md
@@ -40,13 +40,16 @@ sudo apt-get install aws-rotate-iam-keys
 
 ### MacOS
 
+Requires [Homebrew](https://brew.sh/) to install. I am hoping to be included in
+Homebrew Core soon!
+
 ```
 brew tap rhyeal/aws-rotate-iam-keys https://github.com/rhyeal/aws-rotate-iam-keys
 brew install aws-rotate-iam-keys
 ```
 
-Requires [Homebrew](https://brew.sh/) to install. I am hoping to be included in
-Homebrew Core soon!
+Note: this automatically installs/upgrades the `awscli` homebrew package and its
+dependent packages. You can skip this using `brew install aws-rotate-iam-keys --without-awscli`.
 
 ***IMPORTANT:*** You must install your own scheduled job for automated key
 rotation. See [Configuration](#configuration).


### PR DESCRIPTION
Installing via homebrew on MacOS automatically upgrades awscli to the
latest stable version, because the homebrew formula depends on awscli,
and homebrew thinks it's wise to automatically upgrade dependencies.

This might seem sensible in theory, but in practice can cause chaos
because a simple install of aws-rotate-iam-keys can cause both python
and readline to be upgraded/replaced (because awscli depends on python,
and python depends on readline), which breaks anything dependent on the
previously installed versions (e.g. any python packages installed in
develop mode, or any homebrew installed binaries dependent on readline,
e.g. gawk, and other things dependent on those, e.g. bash completion).

Arguably, these are upstream issues, or just symptomatic of how homebrew
is designed to work, and we shouldn't worry about them here; but this is
not the first time a reinstall of aws-rotate-iam-keys has temporarily
crippled my machine, and it would be nice to stop that happening again.

This commit allows that, in the least intrusive way I could find, by
adding an option to `brew install aws-rotate-iam-keys --without-awscli`.