### PR TITLE
WIP: Allow installation of unstable, forked, versions

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -7,6 +7,19 @@ class AwsRotateIamKeys < Formula
   depends_on "gnu-getopt"
   depends_on "jq"
 
+  head do
+    Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '../'))) do
+      url %x{git config --local --get remote.origin.url | tr -d '\n'}, using: :git
+    end
+  end
+
+  devel do
+    Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '../'))) do
+      url %x{git config --local --get remote.origin.url | tr -d '\n'}, using: :git, branch: "develop"
+      version %x{git describe develop --always | tr -d '\n'}
+    end
+  end
+
   def install
     bin.install "src/bin/aws-rotate-iam-keys"
     (buildpath/"aws-rotate-iam-keys").write <<~EOS


### PR DESCRIPTION
Experimental/work in progress. Works for us, but controversial...

Add head and devel specs to the homebrew formula to allow installation
from the master and develop branches respectively of whichever repo is
the source of the homebrew tap. This is fugly, but it seems a necessary
evil to allow us to maintain a usable fork including new features not
yet merged upstream, without breaking upstream compatibility.

Yeah, I know, it's a horrible hack, I hate it too, but it does the job.

P.S. Yes, this will prevent the formula being accepted to Homebrew core,
but that's not going to happen anytime soon, so not worth worrying about