### PR TITLE
Allow whitespace and comments in homebrew config

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -57,7 +57,7 @@ class AwsRotateIamKeys < Formula
       <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <string>if ! curl -s www.google.com > /dev/null; then sleep 60; fi; cp /dev/null /tmp/#{plist_name}.log ; ( cat ~/.aws-rotate-iam-keys 2>/dev/null || cat #{etc}/aws-rotate-iam-keys ) | while read line; do aws-rotate-iam-keys $line; done</string>
+        <string>if ! curl -s www.google.com > /dev/null; then sleep 60; fi; cp /dev/null /tmp/#{plist_name}.log ; ( egrep '^[[:space:]]*-' ~/.aws-rotate-iam-keys 2>/dev/null || cat #{etc}/aws-rotate-iam-keys ) | while read line; do aws-rotate-iam-keys $line; done</string>
       </array>
       <key>StandardOutPath</key>
       <string>/tmp/#{plist_name}.log</string>


### PR DESCRIPTION
Previous code invoked aws-rotate-iam-keys command for every line in the
configuration file, which caused problems when people added blank lines.

I ran into this issue with one user who had added a blank line to the
end of the file, which resulted in the command being invoked without
any options, causing the homebrew service to attempt to rotate keys for
the default profile, which failed because that profile wasn't in use.

Fix by using egrep to only find lines containing what look like options
for the command, allowing for blank lines, commented lines starting with
hash, and leading whitespace before options on otherwise valid lines.

Note: pattern used is POSIX compatible, tested with BSD and GNU egrep