### PR TITLE
Verify new access key before updating credentials

### DIFF
--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -135,23 +135,40 @@ fi
 
 echo "Creating new access key"
 RESPONSE=$(aws iam create-access-key --output json | jq .AccessKey)
-ACCESS_KEY=$(echo $RESPONSE | jq -r '.AccessKeyId')
-SECRET=$(echo $RESPONSE | jq -r '.SecretAccessKey')
-if [[ "$ACCESS_KEY" != "" && "$SECRET" != "" ]]; then
-  echo "Created new key $ACCESS_KEY"
+NEW_ACCESS_KEY_ID=$(echo $RESPONSE | jq -r '.AccessKeyId')
+NEW_SECRET_ACCESS_KEY=$(echo $RESPONSE | jq -r '.SecretAccessKey')
+if [[ "$NEW_ACCESS_KEY_ID" != "" && "$NEW_SECRET_ACCESS_KEY" != "" ]]; then
+  echo "Created new key $NEW_ACCESS_KEY_ID"
+
+  OLD_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+  OLD_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+  export AWS_ACCESS_KEY_ID=$NEW_ACCESS_KEY_ID
+  export AWS_SECRET_ACCESS_KEY=$NEW_SECRET_ACCESS_KEY
+
+  echo "Verifying new access key"
+  for i in $(seq 1 20); do
+    ERROR=$(aws iam list-access-keys 2>&1 1>/dev/null) && break || sleep 3
+  done
+  if [[ $ERROR ]]; then
+    echo $ERROR >&2
+    export AWS_ACCESS_KEY_ID=$OLD_ACCESS_KEY_ID
+    export AWS_SECRET_ACCESS_KEY=$OLD_SECRET_ACCESS_KEY
+    aws iam delete-access-key --access-key-id $NEW_ACCESS_KEY_ID
+    exit 1
+  fi
 
   # Rotate the keys in the credentials file for all profiles
   for i in "${!PROFILES_ARR[@]}"
   do
       echo "Updating profile: ${PROFILES_ARR[i]}"
-      aws configure set aws_access_key_id $ACCESS_KEY --profile ${PROFILES_ARR[i]}
-      aws configure set aws_secret_access_key $SECRET --profile ${PROFILES_ARR[i]}
+      aws configure set aws_access_key_id $NEW_ACCESS_KEY_ID --profile ${PROFILES_ARR[i]}
+      aws configure set aws_secret_access_key $NEW_SECRET_ACCESS_KEY --profile ${PROFILES_ARR[i]}
   done
 
   echo "Deleting old access key"
-  aws iam delete-access-key --access-key-id $AWS_ACCESS_KEY_ID
+  aws iam delete-access-key --access-key-id $OLD_ACCESS_KEY_ID
 
-  echo "Deleted old key $AWS_ACCESS_KEY_ID"
+  echo "Deleted old key $OLD_ACCESS_KEY_ID"
 
   echo "Keys rotated"
   exit 0


### PR DESCRIPTION
I ran into a strange problem whereby a new key was created and the new
access key id and secret access key were written to my credentials file,
but when I tried to use the new credentials I got the following error:

"An error occurred (SignatureDoesNotMatch) when calling the
ListAccessKeys operation: The request signature we calculated does not
match the signature you provided. Check your AWS Secret Access Key and
signing method. Consult the service documentation for details."

This suggests that the access key id and secret access key that were
saved to my credentials file were mismatched. I really don't know how
this happened, but to avoid something like this happening again, I've
added code to test the new credentials before writing them to the
credentials file, and rollback if it fails (i.e. delete the new key).