### PR TITLE
Bugfix/homebrew invalid devel spec

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -16,7 +16,7 @@ class AwsRotateIamKeys < Formula
   devel do
     Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '../'))) do
       url %x{git config --local --get remote.origin.url | tr -d '\n'}, using: :git, branch: "develop"
-      version %x{git describe develop --always | tr -d '\n'}
+      version "head"
     end
   end
 


### PR DESCRIPTION
Fix broken `--devel` installation option for homebrew (generates warnings whenever formula is loaded, i.e. not just when installing `--devel`). See commit message for detailed explanation.

This leaves the devel software spec in place even for taps/repos that don't have a `develop` branch, because determining whether the repo has a develop branch before creating the devel software spec is tricky/hacky (need to chdir to run git command to look for branch before adding the software specs).

So, as it stands, trying to install `--devel` from a tap/repo that doesn't have a `develop` branch will result in an error like:

```
fatal: Couldn't find remote ref refs/heads/develop
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "aws-rotate-iam-keys"
Failure while executing; `git fetch origin` exited with 128. Here's the output:
fatal: Couldn't find remote ref refs/heads/develop
```

This is not ideal, and certainly not pretty, but it seems tolerable for now, at least it only causes a problem when someone specifically tries to install `--devel`.