### PR TITLE
Remove devel software spec, deprecated by Homebrew

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -18,13 +18,6 @@ class AwsRotateIamKeys < Formula
     end
   end
 
-  devel do
-    Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '../'))) do
-      url %x{git config --local --get remote.origin.url | tr -d '\n'}, using: :git, branch: "develop"
-      version "head"
-    end
-  end
-
   def install
     bin.install "src/bin/aws-rotate-iam-keys"
     (buildpath/"aws-rotate-iam-keys").write <<~EOS

--- a/aws-rotate-iam-keys.template.rb
+++ b/aws-rotate-iam-keys.template.rb
@@ -18,13 +18,6 @@ class AwsRotateIamKeys < Formula
     end
   end
 
-  devel do
-    Dir.chdir(File.expand_path(File.join(File.dirname(__FILE__), '../'))) do
-      url %x{git config --local --get remote.origin.url | tr -d '\n'}, using: :git, branch: "develop"
-      version "head"
-    end
-  end
-
   def install
     bin.install "src/bin/aws-rotate-iam-keys"
     (buildpath/"aws-rotate-iam-keys").write <<~EOS


### PR DESCRIPTION
This now causes a deprecation warning every time the formula is loaded

Though we may lament the removal of support for devel software specs,
the Homebrew team have decided this is happening, so we've really no
choice but to remove the offending code block from aws-rotate-iam-keys