### PR TITLE
Disable AWS CLI pager to avoid user interaction

### DIFF
--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -115,6 +115,10 @@ fi
 export AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY
 
+# Disable AWS CLI pager to ensure commands run without prompting for user interaction
+# This should only be relevant when run from a terminal, i.e. when stdout is a tty
+export AWS_PAGER=""
+
 echo "Verifying credentials"
 KEY_COUNT=$(aws iam list-access-keys --output json | jq '.AccessKeyMetadata | length' || exit 1)
 if [[ "$KEY_COUNT" -gt "1" ]]; then


### PR DESCRIPTION
This shouldn't happen when the script is run from cron or homebrew
services, because a pager should only be used when stdout is a tty.

However, issue #50 suggests that there might be an AWS CLI bug that
results in the pager being used even when stdout is not a tty, and
even if that's not the case, we don't want the pager running anyway.