### PR TITLE
Give error on missing profile

### DIFF
--- a/src/bin/aws-rotate-iam-keys
+++ b/src/bin/aws-rotate-iam-keys
@@ -91,8 +91,8 @@ echo "Rotating keys for profiles: $PROFILES"
 echo "Verifying configuration"
 ACCESS_KEY_IDS=()
 for i in "${!PROFILES_ARR[@]}"; do
-  ACCESS_KEY_ID=$(aws configure get ${PROFILES_ARR[i]}.aws_access_key_id 2>/dev/null)
-  SECRET_ACCESS_KEY=$(aws configure get ${PROFILES_ARR[i]}.aws_secret_access_key 2>/dev/null)
+  ACCESS_KEY_ID=$(aws configure get ${PROFILES_ARR[i]}.aws_access_key_id 2>/dev/null || echo "")
+  SECRET_ACCESS_KEY=$(aws configure get ${PROFILES_ARR[i]}.aws_secret_access_key 2>/dev/null || echo "")
   if [[ -z "$ACCESS_KEY_ID" ]] || [[ -z "$SECRET_ACCESS_KEY" ]]; then
     echo "Could not find keys for profile ${PROFILES_ARR[i]}. Ensure you have a profile set up using 'aws configure'." >&2
     exit 1


### PR DESCRIPTION
set -e option causes these 2 lines to exit the script upon problems with 'aws configure...' (missing profile, for example). Adding the '|| echo ""' causes this command to return an empty string, so the subsequent check can give a proper error message, THEN exit.