### PR TITLE
Adds default brew arm64 path

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -60,7 +60,7 @@ class AwsRotateIamKeys < Formula
       <key>EnvironmentVariables</key>
       <dict>
         <key>PATH</key>
-        <string>/opt/homebrew/bin/:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
       </dict>
       <key>Label</key>
       <string>#{plist_name}</string>

--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -60,7 +60,7 @@ class AwsRotateIamKeys < Formula
       <key>EnvironmentVariables</key>
       <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>/opt/homebrew/bin/:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
       </dict>
       <key>Label</key>
       <string>#{plist_name}</string>


### PR DESCRIPTION
This PR adds the default path for homebrew running on arm64 / Apple Silicon.

Presently launchd cannot locate the binary in the scheduled job.