### PR TITLE
Prepend the bin to PATH for Homebrew service plist

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -60,7 +60,7 @@ class AwsRotateIamKeys < Formula
       <key>EnvironmentVariables</key>
       <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>#{bin}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
       </dict>
       <key>Label</key>
       <string>#{plist_name}</string>


### PR DESCRIPTION
The defaults here used to work, until Homebrew started living in /opt/homebrew. Since it could live anywhere--or multiple places even--prepend the bin path to `$PATH`