### PR TITLE
Fix missing/incorrect script version on homebrew

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -20,6 +20,7 @@ class AwsRotateIamKeys < Formula
 
   def install
     bin.install "src/bin/aws-rotate-iam-keys"
+    inreplace "#{bin}/aws-rotate-iam-keys", "<%VERSION%>", version
     (buildpath/"aws-rotate-iam-keys").write <<~EOS
       --profile default
     EOS


### PR DESCRIPTION
The version of the installed aws-rotate-iam-keys script is set a build
time on Debian, by replacing a template string in the source file, but
this step is missing from the homebrew build, and can't easily be added
as the homebrew version just downloads the repo as an archive, but we
can add it as part of the formula install, which I have done here.

Although this fixes the immediate issue, also feels very much like a
hack, and one that doesn't help anyone installing from source, rather
than the Homebrew formula or Debian package (they still see the version
as <%VERSION%>). Not sure what the answer is, but it's worth a think.

Fixes #61
