### PR TITLE
Add Homebrew path for Apple Silicon

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -60,7 +60,7 @@ class AwsRotateIamKeys < Formula
       <key>EnvironmentVariables</key>
       <dict>
         <key>PATH</key>
-        <string>#{bin}:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>#{bin}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
       </dict>
       <key>Label</key>
       <string>#{plist_name}</string>


### PR DESCRIPTION
## Issue
When executed as a service on `macOS` on an Apple Silicon machine, the script is not able to find the brew binary due to it being located under `/opt/homebrew/bin/`.

Proof of this is visible in the `/tmp/homebrew.mxcl.aws-rotate-iam-keys.log` log file:
```plaintext
➜  ~ cat /tmp/homebrew.mxcl.aws-rotate-iam-keys.log
GNU's enhanced getopt is required to run this script
You can usually find this in the util-linux package
On MacOS see homebrew's package: http://brewformulas.org/Gnu-getopt
For anyone else, build from source: http://frodo.looijaard.name/project/getopt
```

The output can be misleading because it fails on the first part of the if condition where it tries to identify the `brew` binary but fails.

Hence the script won't work if scheduled as a service.

## Solution

Adding the Apple Silicon Homebrew binary path to the Plist file in the Environment variables section fixes the problem.