### PR TITLE
Fix brew warning

### DIFF
--- a/Formula/aws-rotate-iam-keys.rb
+++ b/Formula/aws-rotate-iam-keys.rb
@@ -50,7 +50,7 @@ class AwsRotateIamKeys < Formula
     EOS
   end
 
-  plist_options :startup => false
+  service.require_root :startup => false
 
   def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This PR to fix the problem:

```
Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the rhyeal/aws-rotate-iam-keys tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/rhyeal/homebrew-aws-rotate-iam-keys/Formula/aws-rotate-iam-keys.rb:53
```