### PR TITLE
brew: improve formula to remove deprecated syntax

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -188,14 +188,14 @@ The Homebrew formula installs a launchd job which can be used to automatically
 rotate your IAM keys daily. Unfortunately, Homebrew forumlae cannot
 automatically start launchd jobs, so you must manually enable it:
 
-```
+```sh
 brew services start aws-rotate-iam-keys
 ```
 
 A default/global configuration file for the launchd job is installed to:
 
-```
-/usr/local/etc/aws-rotate-iam-keys
+```sh
+$(brew --prefix)/etc/aws-rotate-iam-keys
 ```
 
 This default configuration rotates keys for your default AWS profile only.
@@ -203,8 +203,8 @@ To customise the configuration, for example to rotate multiple keys, create a
 copy of this file named `.aws-rotate-iam-keys` in your home directory and edit
 it, e.g.
 
-```
-cp /usr/local/etc/aws-rotate-iam-keys ~/.aws-rotate-iam-keys
+```sh
+cp $(brew --prefix)/etc/aws-rotate-iam-keys ~/.aws-rotate-iam-keys
 nano ~/.aws-rotate-iam-keys
 ```
 
@@ -221,7 +221,7 @@ multiple lines to the configuration, e.g.
 If you do customise the configuration, you can test that it works by restarting
 the service:
 
-```
+```sh
 brew services restart aws-rotate-iam-keys
 ```
 
@@ -229,16 +229,16 @@ That's it. Your keys should have been rotated, and will now be rotated every
 day for you. You can use the AWS CLI to check that your access keys have been
 rotated as expected, e.g.
 
-```
+```sh
 aws iam list-access-keys --profile default
 ```
 
 If it hasn't worked, check the MacOS system log for error entries matching
 `aws-rotate-iam-keys`. If you can't find anything useful, the launchd job also
-writes output to a file in the `/tmp` directory matching the job name, e.g.
+writes output to a file in the `$(brew --prefix)/var/log` directory matching the job name, e.g.
 
-```
-/tmp/homebrew.mxcl.aws-rotate-iam-keys.log
+```sh
+cat /opt/homebrew/var/log/homebrew.mxcl.aws-rotate-iam-keys.log
 ```
 
 ### Other Linux

--- a/README.template.md
+++ b/README.template.md
@@ -235,10 +235,10 @@ aws iam list-access-keys --profile default
 
 If it hasn't worked, check the MacOS system log for error entries matching
 `aws-rotate-iam-keys`. If you can't find anything useful, the launchd job also
-writes output to a file in the `$(brew --prefix)/var/log` directory matching the job name, e.g.
+writes output to a file in the `/tmp` directory matching the job name, e.g.
 
 ```sh
-cat /opt/homebrew/var/log/homebrew.mxcl.aws-rotate-iam-keys.log
+cat /tmp/homebrew.mxcl.aws-rotate-iam-keys.log
 ```
 
 ### Other Linux
@@ -251,7 +251,7 @@ EDITOR=nano crontab -e
 
 Copy and paste the following line into the end of the crontab file:
 
-```
+```cron
 33 4 * * * /usr/bin/aws-rotate-iam-keys --profile default >/dev/null #rotate AWS keys daily
 ```
 

--- a/aws-rotate-iam-keys.template.rb
+++ b/aws-rotate-iam-keys.template.rb
@@ -54,7 +54,7 @@ class AwsRotateIamKeys < Formula
   service do
     run ["bash", "-c", "if ! curl -s www.google.com; then sleep 60; fi; cp /dev/null #{f.log_path} ; ( grep -E ^[[:space:]]*- ~/.aws-rotate-iam-keys || cat #{etc}/aws-rotate-iam-keys ) | while read line; do #{opt_bin}/aws-rotate-iam-keys $line; done"]
     run_type :cron
-    run_at_load false
+    run_at_load true
     cron "23 3 * * *"
     environment_variables PATH: std_service_path_env
     log_path f.log_path

--- a/aws-rotate-iam-keys.template.rb
+++ b/aws-rotate-iam-keys.template.rb
@@ -49,7 +49,7 @@ class AwsRotateIamKeys < Formula
   end
 
   def log_path
-    var/"log/#{plist_name}.log"
+    "/tmp/#{plist_name}.log"
   end
   service do
     run ["bash", "-c", "if ! curl -s www.google.com; then sleep 60; fi; cp /dev/null #{f.log_path} ; ( grep -E ^[[:space:]]*- ~/.aws-rotate-iam-keys || cat #{etc}/aws-rotate-iam-keys ) | while read line; do #{opt_bin}/aws-rotate-iam-keys $line; done"]

--- a/aws-rotate-iam-keys.template.rb
+++ b/aws-rotate-iam-keys.template.rb
@@ -12,6 +12,10 @@ class AwsRotateIamKeys < Formula
   depends_on "jq"
   depends_on "awscli" => :recommended
 
+  head do
+    url "https://github.com/rhyeal/aws-rotate-iam-keys.git"
+  end
+
   def install
     bin.install "src/bin/aws-rotate-iam-keys"
     (buildpath/"aws-rotate-iam-keys").write <<~EOS
@@ -45,11 +49,12 @@ class AwsRotateIamKeys < Formula
   end
 
   def log_path
-    var/"log/#{name}.log"
+    var/"log/#{plist_name}.log"
   end
   service do
-    run opt_bin/"aws-rotate-iam-keys"
+    run ["bash", "-c", "if ! curl -s www.google.com; then sleep 60; fi; cp /dev/null #{f.log_path} ; ( grep -E ^[[:space:]]*- ~/.aws-rotate-iam-keys || cat #{etc}/aws-rotate-iam-keys ) | while read line; do #{opt_bin}/aws-rotate-iam-keys $line; done"]
     run_type :cron
+    run_at_load false
     cron "23 3 * * *"
     environment_variables PATH: std_service_path_env
     log_path f.log_path


### PR DESCRIPTION
Updates the formula to no longer rely on deprecated plist functionality.
Fixes the issue with the service failing due to hardcoded PATH variable
for the service. Generates the service manifest dynamically instead of
embedding it into the formula.

closes #74

Signed-off-by: Ismayil Mirzali <ismayilmirzeli@gmail.com>
