### PR TITLE
docs: added command for apple silicon

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -208,6 +208,8 @@ cp /usr/local/etc/aws-rotate-iam-keys ~/.aws-rotate-iam-keys
 nano ~/.aws-rotate-iam-keys
 ```
 
+Note: if you are using Apple Silicon: `cp /opt/homebrew/etc/aws-rotate-iam-keys ~/.aws-rotate-iam-keys`
+
 The `aws-rotate-iam-keys` command is invoked once daily for each line in the
 configuration. Each line contains a single set of command line options. If you
 need to invoke the command multiple times to rotate your keys, you must add


### PR DESCRIPTION
This change is intended to show apple silicon users how to copy configuration files.

Since apple silicon has a different PATH for copying configuration files, I thought it would be helpful to indicate this in the README.